### PR TITLE
Add Swift 6.4 Linux row to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,13 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+          # swift:6.0 exercises the UnitFrequency.framesPerSecond shim
+          # (gated to compiler(<6.4)); swift:6.4 exercises the path where
+          # Foundation provides framesPerSecond natively and the shim is off.
           - os: ubuntu-latest
             container: swift:6.0
+          - os: ubuntu-latest
+            container: swift:6.4
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:


### PR DESCRIPTION
## What

Adds a `swift:6.4` Linux container to the `build-and-test` matrix, alongside the existing `swift:6.0` row.

## Why

The Linux matrix only pinned `swift:6.0`, which exercises **only** the `UnitFrequency.framesPerSecond` shim (gated to `compiler(<6.4)`). Swift 6.4 ships `framesPerSecond` natively in Foundation, so the post-shim path — where the shim is disabled and Foundation supplies the symbol — was previously untested.

After this change the matrix covers all three relevant paths:

| Row | Path exercised |
|---|---|
| `macos-latest` | host toolchain (Darwin — shim never applies) |
| `ubuntu-latest` + `swift:6.0` | the `framesPerSecond` **shim** path |
| `ubuntu-latest` + `swift:6.4` | the **native** path (shim off, Foundation provides the symbol) |

This also makes CI the trigger that confirms when the shim can eventually be removed (once the minimum supported toolchain reaches 6.4).
