### PR TITLE
Add SwiftMeasurementCodable: stable Measurement JSON via CLDR unit identifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,26 @@ jobs:
 
       - name: Run tests
         run: swift test
+
+      # --- SwiftMeasurementCodable: explicit verification of the standalone product ---
+      # The steps above already compile and test the whole package (including this
+      # target) on both macOS and Linux. The steps below make the module's guarantees
+      # explicit, named, and durable — so a future change to the package-wide steps
+      # can't silently drop coverage of the Codable product.
+      - name: Verify SwiftMeasurementCodable is Foundation-only
+        run: |
+          bad=$(grep -rhE '^[[:space:]]*import ' Sources/SwiftMeasurementCodable | grep -vE '^[[:space:]]*import Foundation[[:space:]]*$' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::SwiftMeasurementCodable must import only Foundation — it is a standalone product and must not depend on the SwiftMeasurement target. Found:"
+            echo "$bad"
+            exit 1
+          fi
+
+      - name: Build SwiftMeasurementCodable product (Debug)
+        run: swift build --product SwiftMeasurementCodable
+
+      - name: Build SwiftMeasurementCodable product (Release)
+        run: swift build --product SwiftMeasurementCodable -c release
+
+      - name: Test SwiftMeasurementCodable
+        run: swift test --filter SwiftMeasurementCodableTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,25 +28,30 @@ jobs:
       - name: Run tests
         run: swift test
 
-      # --- SwiftMeasurementCodable: explicit verification of the standalone product ---
+      # --- SwiftMeasurementCodable: explicit verification of the standalone target ---
       # The steps above already compile and test the whole package (including this
       # target) on both macOS and Linux. The steps below make the module's guarantees
       # explicit, named, and durable — so a future change to the package-wide steps
-      # can't silently drop coverage of the Codable product.
-      - name: Verify SwiftMeasurementCodable is Foundation-only
+      # can't silently drop coverage of the Codable module.
+      - name: Verify SwiftMeasurementCodable does not depend on SwiftMeasurement
         run: |
-          bad=$(grep -rhE '^[[:space:]]*import ' Sources/SwiftMeasurementCodable | grep -vE '^[[:space:]]*import Foundation[[:space:]]*$' || true)
+          # The module must stay standalone: it may import Foundation and platform
+          # modules (Glibc/Darwin), but never the SwiftMeasurement target. Match a real
+          # import of that module — including @testable / @_implementationOnly / scoped
+          # forms — without tripping on `SwiftMeasurementCodable`, comments, Foundation
+          # submodules, or system modules.
+          bad=$(grep -rnE '^[[:space:]]*(@[[:alnum:]_]+[[:space:]]+)?import([[:space:]]+[[:lower:]]+)?[[:space:]]+SwiftMeasurement([[:space:]]|\.|$)' Sources/SwiftMeasurementCodable || true)
           if [ -n "$bad" ]; then
-            echo "::error::SwiftMeasurementCodable must import only Foundation — it is a standalone product and must not depend on the SwiftMeasurement target. Found:"
+            echo "::error::SwiftMeasurementCodable must not import the SwiftMeasurement target — it is a standalone product. Found:"
             echo "$bad"
             exit 1
           fi
 
-      - name: Build SwiftMeasurementCodable product (Debug)
-        run: swift build --product SwiftMeasurementCodable
+      - name: Build SwiftMeasurementCodable target (Debug)
+        run: swift build --target SwiftMeasurementCodable
 
-      - name: Build SwiftMeasurementCodable product (Release)
-        run: swift build --product SwiftMeasurementCodable -c release
+      - name: Build SwiftMeasurementCodable target (Release)
+        run: swift build --target SwiftMeasurementCodable -c release
 
       - name: Test SwiftMeasurementCodable
         run: swift test --filter SwiftMeasurementCodableTests

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,13 @@ let package = Package(
                 "SwiftMeasurement",
             ]
         ),
+
+        .library(
+            name: "SwiftMeasurementCodable",
+            targets: [
+                "SwiftMeasurementCodable",
+            ]
+        ),
     ],
 
     targets: [
@@ -27,10 +34,21 @@ let package = Package(
             name: "SwiftMeasurement"
         ),
 
+        .target(
+            name: "SwiftMeasurementCodable"
+        ),
+
         .testTarget(
             name: "SwiftMeasurementTests",
             dependencies: [
                 "SwiftMeasurement",
+            ]
+        ),
+
+        .testTarget(
+            name: "SwiftMeasurementCodableTests",
+            dependencies: [
+                "SwiftMeasurementCodable",
             ]
         ),
     ],

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A standalone product (no dependency on the `SwiftMeasurement` module) that encod
 `unit` is a [CLDR core unit identifier](https://www.unicode.org/reports/tr35/tr35-general.html#Unit_Elements) (CLDR 48.2) — the same vocabulary JavaScript's [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#unit) accepts, so payloads stay locale-neutral and readable from any ecosystem. Foundation's built-in `Measurement` Codable shape (display symbols plus converter internals) is neither.
 
 ```swift
+import Foundation
 import SwiftMeasurementCodable
 
 struct Recipe: Codable {

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ let recipe = Recipe(
     flour: Measurement(value: 500, unit: .grams).codable,
     oven: Measurement(value: 220, unit: .celsius).codable
 )
-let data = try JSONEncoder().encode(recipe)
-// {"flour":{"value":500,"unit":"gram"},"oven":{"value":220,"unit":"celsius"}}
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.sortedKeys]   // stable key order on every platform
+let data = try encoder.encode(recipe)
+// {"flour":{"unit":"gram","value":500},"oven":{"unit":"celsius","value":220}}
 
 let decoded = try JSONDecoder().decode(Recipe.self, from: data)
 decoded.flour.measurement.converted(to: .ounces)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,52 @@ Typed accessors (`.asLength`, `.asArea`, `.asSpeed`, `.asEnergy`, etc.) convert 
 
 </details>
 
+## SwiftMeasurementCodable
+
+A standalone product (no dependency on the `SwiftMeasurement` module) that encodes and decodes `Measurement` values as stable, portable JSON:
+
+```json
+{"value": 21.5, "unit": "gram"}
+```
+
+`unit` is a [CLDR core unit identifier](https://www.unicode.org/reports/tr35/tr35-general.html#Unit_Elements) (CLDR 48.2) — the same vocabulary JavaScript's [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#unit) accepts, so payloads stay locale-neutral and readable from any ecosystem. Foundation's built-in `Measurement` Codable shape (display symbols plus converter internals) is neither.
+
+```swift
+import SwiftMeasurementCodable
+
+struct Recipe: Codable {
+    var flour: CodableMeasurement<UnitMass>
+    var oven: CodableMeasurement<UnitTemperature>
+}
+
+let recipe = Recipe(
+    flour: Measurement(value: 500, unit: .grams).codable,
+    oven: Measurement(value: 220, unit: .celsius).codable
+)
+let data = try JSONEncoder().encode(recipe)
+// {"flour":{"value":500,"unit":"gram"},"oven":{"value":220,"unit":"celsius"}}
+
+let decoded = try JSONDecoder().decode(Recipe.self, from: data)
+decoded.flour.measurement.converted(to: .ounces)
+```
+
+Add the product to your target:
+
+```swift
+.product(name: "SwiftMeasurementCodable", package: "SwiftMeasurement")
+```
+
+**Strict or lenient.** `CodableMeasurement` throws `DecodingError` on an unrecognized identifier. When your policy is "an unrecognized unit means the value is absent", decode `RawMeasurement` instead — it always succeeds, and typed access is failable:
+
+```swift
+let raw = try JSONDecoder().decode(RawMeasurement.self, from: json)
+let mass: Measurement<UnitMass>? = raw.measurement(as: UnitMass.self)
+```
+
+**Mapping primitives.** The `UnitIdentifierRepresentable` protocol exposes both directions for custom wire shapes — `UnitMass.grams.unitIdentifier == "gram"` and `UnitMass.unit(forIdentifier: "ounce") == .ounces` — and lets you conform your own `Dimension` subclasses (see the protocol's documentation for the recipe).
+
+Notes: encoding emits the measurement's current unit as-is (convert first to control the wire unit); all 22 Foundation `Dimension` types are covered for every constant with a regular CLDR 48.2 identifier; a few identifiers (e.g. `bar`) are valid CLDR but outside the smaller [ECMA-402 sanctioned subset](https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers) that `Intl.NumberFormat` formats.
+
 ## Installation
 
 **Xcode:** File > Add Package Dependencies > enter `https://github.com/ken0nek/SwiftMeasurement.git`

--- a/Sources/SwiftMeasurementCodable/CodableMeasurement.swift
+++ b/Sources/SwiftMeasurementCodable/CodableMeasurement.swift
@@ -6,6 +6,11 @@ import Foundation
 /// canonicalization. Convert first (`measurement.converted(to:)`) to control the unit
 /// on the wire. Decoding an identifier the unit type does not recognize throws
 /// `DecodingError`; for a lenient alternative see `RawMeasurement`.
+///
+/// `Equatable` compares the wrapped `Measurement` *dimensionally* (as `Measurement`
+/// does), so two wrappers with equal magnitude but different units — e.g. 1 kg and
+/// 1000 g — are `==` even though they encode to different JSON. If you need equality
+/// that mirrors the wire bytes, compare `measurement.value` and `measurement.unit`.
 public struct CodableMeasurement<UnitType: UnitIdentifierRepresentable>: Equatable, Sendable {
     /// The wrapped measurement.
     public var measurement: Measurement<UnitType>
@@ -37,7 +42,9 @@ extension CodableMeasurement: Codable {
         self.init(Measurement(value: value, unit: unit))
     }
 
-    /// Encodes `{"value", "unit"}`; throws `EncodingError` if the current unit has no identifier.
+    /// Encodes `{"value", "unit"}`. Throws `EncodingError` if the current unit has no
+    /// identifier, or — under `JSONEncoder`'s default non-conforming-float strategy — if
+    /// the value is non-finite (NaN or infinity).
     public func encode(to encoder: any Encoder) throws {
         guard let identifier = measurement.unit.unitIdentifier else {
             throw EncodingError.invalidValue(

--- a/Sources/SwiftMeasurementCodable/CodableMeasurement.swift
+++ b/Sources/SwiftMeasurementCodable/CodableMeasurement.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Wraps a `Measurement` in the stable wire shape `{"value": <number>, "unit": "<cldr-id>"}`.
+///
+/// Encoding emits the measurement's *current* unit's identifier — no conversion or
+/// canonicalization. Convert first (`measurement.converted(to:)`) to control the unit
+/// on the wire. Decoding an identifier the unit type does not recognize throws
+/// `DecodingError`; for a lenient alternative see `RawMeasurement`.
+public struct CodableMeasurement<UnitType: UnitIdentifierRepresentable>: Equatable, Sendable {
+    /// The wrapped measurement.
+    public var measurement: Measurement<UnitType>
+
+    /// Wraps a measurement for encoding and decoding.
+    public init(_ measurement: Measurement<UnitType>) {
+        self.measurement = measurement
+    }
+}
+
+extension CodableMeasurement: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case unit
+    }
+
+    /// Decodes `{"value", "unit"}`; throws `DecodingError` if the identifier is unrecognized.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let value = try container.decode(Double.self, forKey: .value)
+        let identifier = try container.decode(String.self, forKey: .unit)
+        guard let unit = UnitType.unit(forIdentifier: identifier) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .unit,
+                in: container,
+                debugDescription: "Unrecognized unit identifier \"\(identifier)\" for \(UnitType.self)"
+            )
+        }
+        self.init(Measurement(value: value, unit: unit))
+    }
+
+    /// Encodes `{"value", "unit"}`; throws `EncodingError` if the current unit has no identifier.
+    public func encode(to encoder: any Encoder) throws {
+        guard let identifier = measurement.unit.unitIdentifier else {
+            throw EncodingError.invalidValue(
+                measurement,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: """
+                    Unit "\(measurement.unit.symbol)" of \(UnitType.self) has no unit identifier. \
+                    Convert to a mapped unit with converted(to:), or conform your custom unit type.
+                    """
+                )
+            )
+        }
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(measurement.value, forKey: .value)
+        try container.encode(identifier, forKey: .unit)
+    }
+}
+
+extension Measurement where UnitType: UnitIdentifierRepresentable {
+    /// The measurement wrapped for `{"value", "unit"}` encoding:
+    /// `Measurement(value: 21.5, unit: UnitMass.grams).codable`.
+    public var codable: CodableMeasurement<UnitType> { .init(self) }
+}

--- a/Sources/SwiftMeasurementCodable/RawMeasurement.swift
+++ b/Sources/SwiftMeasurementCodable/RawMeasurement.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The `{"value", "unit"}` wire pair with the unit identifier kept as a raw string.
+///
+/// Decoding never fails on an unrecognized identifier — use this instead of
+/// `CodableMeasurement` when your policy is "an unrecognized unit means the
+/// quantity is absent". Typed interpretation is a separate, failable step:
+///
+/// ```swift
+/// let raw = try JSONDecoder().decode(RawMeasurement.self, from: json)
+/// let mass = raw.measurement(as: UnitMass.self)   // nil if unrecognized
+/// ```
+public struct RawMeasurement: Codable, Equatable, Sendable {
+    /// The numeric value as it appears on the wire.
+    public var value: Double
+
+    /// The unit identifier string as it appears on the wire (key: `unit`).
+    public var unitIdentifier: String
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case unitIdentifier = "unit"
+    }
+
+    /// Creates a raw wire pair.
+    public init(value: Double, unitIdentifier: String) {
+        self.value = value
+        self.unitIdentifier = unitIdentifier
+    }
+
+    /// The typed measurement, or `nil` when the identifier isn't recognized by that unit type.
+    public func measurement<UnitType: UnitIdentifierRepresentable>(
+        as unitType: UnitType.Type
+    ) -> Measurement<UnitType>? {
+        guard let unit = UnitType.unit(forIdentifier: unitIdentifier) else { return nil }
+        return Measurement(value: value, unit: unit)
+    }
+}

--- a/Sources/SwiftMeasurementCodable/UnitIdentifierRepresentable.swift
+++ b/Sources/SwiftMeasurementCodable/UnitIdentifierRepresentable.swift
@@ -34,10 +34,10 @@ import Foundation
 ///
 /// The trailing `as? Self` cast is required because Foundation's unit classes are
 /// non-final; for a subclass of the conforming class the cast fails and the lookup
-/// correctly returns `nil`. Note that `Unit` equality is symbol-based, so a custom
-/// unit constructed with a colliding symbol (`UnitMass(symbol: "g")`) matches the
-/// standard constant's switch case even if its converter differs — symbol
-/// collisions are the consumer's responsibility to avoid.
+/// correctly returns `nil`. Note that Foundation compares `Dimension` units by both
+/// symbol and converter, so a custom unit matches a standard constant's `switch` case
+/// only when both its symbol and its converter are identical to that constant's; a
+/// unit with a standard symbol but a different converter falls through to `nil`.
 public protocol UnitIdentifierRepresentable: Dimension {
     /// The CLDR core unit identifier for this unit (e.g. `"gram"`),
     /// or `nil` if this unit has no CLDR identifier.

--- a/Sources/SwiftMeasurementCodable/UnitIdentifierRepresentable.swift
+++ b/Sources/SwiftMeasurementCodable/UnitIdentifierRepresentable.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// A `Dimension` subclass whose units map to CLDR core unit identifiers.
+///
+/// CLDR core unit identifiers (`"gram"`, `"celsius"`, `"kilometer-per-hour"`) are
+/// locale-neutral, standardized strings — the same vocabulary JavaScript's
+/// `Intl.NumberFormat` accepts — making them suitable as a stable wire format,
+/// unlike display symbols (`"g"`, `"°C"`) or Foundation's built-in `Measurement`
+/// encoding. Identifiers follow CLDR 48.2 (`idStatus='regular'` only).
+///
+/// Conform your own `Dimension` subclass by switching over its units in both
+/// directions:
+///
+/// ```swift
+/// extension UnitCaffeine: UnitIdentifierRepresentable {
+///     public var unitIdentifier: String? {
+///         switch self {
+///         case .milligrams: "milligram-caffeine"
+///         default:          nil
+///         }
+///     }
+///
+///     public static func unit(forIdentifier identifier: String) -> Self? {
+///         let unit: UnitCaffeine?
+///         switch identifier {
+///         case "milligram-caffeine": unit = .milligrams
+///         default:                   unit = nil
+///         }
+///         guard let unit else { return nil }
+///         return unit as? Self
+///     }
+/// }
+/// ```
+///
+/// The trailing `as? Self` cast is required because Foundation's unit classes are
+/// non-final; for a subclass of the conforming class the cast fails and the lookup
+/// correctly returns `nil`. Note that `Unit` equality is symbol-based, so a custom
+/// unit constructed with a colliding symbol (`UnitMass(symbol: "g")`) matches the
+/// standard constant's switch case even if its converter differs — symbol
+/// collisions are the consumer's responsibility to avoid.
+public protocol UnitIdentifierRepresentable: Dimension {
+    /// The CLDR core unit identifier for this unit (e.g. `"gram"`),
+    /// or `nil` if this unit has no CLDR identifier.
+    var unitIdentifier: String? { get }
+
+    /// The unit for a CLDR core unit identifier,
+    /// or `nil` if this unit type does not recognize the identifier.
+    static func unit(forIdentifier identifier: String) -> Self?
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitAcceleration+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitAcceleration+Identifiers.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitAcceleration`. All constants are mapped.
+extension UnitAcceleration: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .metersPerSecondSquared: "meter-per-square-second"
+        case .gravity:                "g-force"
+        default:                      nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitAcceleration?
+        switch identifier {
+        case "meter-per-square-second": unit = .metersPerSecondSquared
+        case "g-force":                 unit = .gravity
+        default:                        unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitAngle+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitAngle+Identifiers.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitAngle`. Unmapped constants (no regular CLDR id):
+/// `gradians`.
+extension UnitAngle: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .degrees:     "degree"
+        case .arcMinutes:  "arc-minute"
+        case .arcSeconds:  "arc-second"
+        case .radians:     "radian"
+        case .revolutions: "revolution"
+        default:           nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitAngle?
+        switch identifier {
+        case "degree":     unit = .degrees
+        case "arc-minute": unit = .arcMinutes
+        case "arc-second": unit = .arcSeconds
+        case "radian":     unit = .radians
+        case "revolution": unit = .revolutions
+        default:           unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitArea+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitArea+Identifiers.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitArea`. Unmapped constants (no regular CLDR id):
+/// `squareMegameters`, `squareMillimeters`, `squareMicrometers`,
+/// `squareNanometers`, `ares`.
+extension UnitArea: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .squareKilometers:  "square-kilometer"
+        case .squareMeters:      "square-meter"
+        case .squareCentimeters: "square-centimeter"
+        case .squareInches:      "square-inch"
+        case .squareFeet:        "square-foot"
+        case .squareYards:       "square-yard"
+        case .squareMiles:       "square-mile"
+        case .acres:             "acre"
+        case .hectares:          "hectare"
+        default:                 nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitArea?
+        switch identifier {
+        case "square-kilometer":  unit = .squareKilometers
+        case "square-meter":      unit = .squareMeters
+        case "square-centimeter": unit = .squareCentimeters
+        case "square-inch":       unit = .squareInches
+        case "square-foot":       unit = .squareFeet
+        case "square-yard":       unit = .squareYards
+        case "square-mile":       unit = .squareMiles
+        case "acre":              unit = .acres
+        case "hectare":           unit = .hectares
+        default:                  unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitConcentrationMass+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitConcentrationMass+Identifiers.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitConcentrationMass`: none exist.
+/// `gramsPerLiter` has no regular CLDR id; `milligramsPerDeciliter` is deliberately
+/// unmapped because CLDR's only candidate (`milligram-ofglucose-per-deciliter`) is
+/// glucose-specific while Foundation's unit is a generic mass concentration.
+extension UnitConcentrationMass: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        nil
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        nil
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitDispersion+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitDispersion+Identifiers.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitDispersion`. All constants are mapped.
+extension UnitDispersion: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .partsPerMillion: "part-per-1e6"
+        default:               nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitDispersion?
+        switch identifier {
+        case "part-per-1e6": unit = .partsPerMillion
+        default:             unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitDuration+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitDuration+Identifiers.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitDuration`. Unmapped constants (no regular CLDR
+/// id): `picoseconds`.
+extension UnitDuration: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .hours:        "hour"
+        case .minutes:      "minute"
+        case .seconds:      "second"
+        case .milliseconds: "millisecond"
+        case .microseconds: "microsecond"
+        case .nanoseconds:  "nanosecond"
+        default:            nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitDuration?
+        switch identifier {
+        case "hour":        unit = .hours
+        case "minute":      unit = .minutes
+        case "second":      unit = .seconds
+        case "millisecond": unit = .milliseconds
+        case "microsecond": unit = .microseconds
+        case "nanosecond":  unit = .nanoseconds
+        default:            unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitElectricCharge+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitElectricCharge+Identifiers.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitElectricCharge`. Unmapped constants (no regular
+/// CLDR id): `megaampereHours`, `kiloampereHours`, `ampereHours`,
+/// `milliampereHours`, `microampereHours`.
+extension UnitElectricCharge: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .coulombs: "coulomb"
+        default:        nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitElectricCharge?
+        switch identifier {
+        case "coulomb": unit = .coulombs
+        default:        unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitElectricCurrent+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitElectricCurrent+Identifiers.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitElectricCurrent`. Unmapped constants (no regular
+/// CLDR id): `megaamperes`, `kiloamperes`, `microamperes`.
+extension UnitElectricCurrent: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .amperes:      "ampere"
+        case .milliamperes: "milliampere"
+        default:            nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitElectricCurrent?
+        switch identifier {
+        case "ampere":      unit = .amperes
+        case "milliampere": unit = .milliamperes
+        default:            unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitElectricPotentialDifference+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitElectricPotentialDifference+Identifiers.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitElectricPotentialDifference`. Unmapped constants
+/// (no regular CLDR id): `megavolts`, `kilovolts`, `millivolts`, `microvolts`.
+extension UnitElectricPotentialDifference: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .volts: "volt"
+        default:     nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitElectricPotentialDifference?
+        switch identifier {
+        case "volt": unit = .volts
+        default:     unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitElectricResistance+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitElectricResistance+Identifiers.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitElectricResistance`. Unmapped constants (no
+/// regular CLDR id): `megaohms`, `kiloohms`, `milliohms`, `microohms`.
+extension UnitElectricResistance: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .ohms: "ohm"
+        default:    nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitElectricResistance?
+        switch identifier {
+        case "ohm": unit = .ohms
+        default:    unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitEnergy+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitEnergy+Identifiers.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitEnergy`. All constants are mapped.
+extension UnitEnergy: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .kilojoules:    "kilojoule"
+        case .joules:        "joule"
+        case .kilocalories:  "kilocalorie"
+        case .calories:      "calorie"
+        case .kilowattHours: "kilowatt-hour"
+        default:             nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitEnergy?
+        switch identifier {
+        case "kilojoule":     unit = .kilojoules
+        case "joule":         unit = .joules
+        case "kilocalorie":   unit = .kilocalories
+        case "calorie":       unit = .calories
+        case "kilowatt-hour": unit = .kilowattHours
+        default:              unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitFrequency+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitFrequency+Identifiers.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitFrequency`. Unmapped constants (no regular CLDR
+/// id): `terahertz`, `millihertz`, `microhertz`, `nanohertz`, `framesPerSecond`.
+/// `framesPerSecond`'s availability is platform-gated, so it is never referenced in
+/// this file's switch cases.
+extension UnitFrequency: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .gigahertz: "gigahertz"
+        case .megahertz: "megahertz"
+        case .kilohertz: "kilohertz"
+        case .hertz:     "hertz"
+        default:         nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitFrequency?
+        switch identifier {
+        case "gigahertz": unit = .gigahertz
+        case "megahertz": unit = .megahertz
+        case "kilohertz": unit = .kilohertz
+        case "hertz":     unit = .hertz
+        default:          unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitFuelEfficiency+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitFuelEfficiency+Identifiers.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitFuelEfficiency`. All constants are mapped.
+extension UnitFuelEfficiency: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .litersPer100Kilometers: "liter-per-100-kilometer"
+        case .milesPerGallon:         "mile-per-gallon"
+        case .milesPerImperialGallon: "mile-per-gallon-imperial"
+        default:                      nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitFuelEfficiency?
+        switch identifier {
+        case "liter-per-100-kilometer":  unit = .litersPer100Kilometers
+        case "mile-per-gallon":          unit = .milesPerGallon
+        case "mile-per-gallon-imperial": unit = .milesPerImperialGallon
+        default:                         unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitIlluminance+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitIlluminance+Identifiers.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitIlluminance`. All constants are mapped.
+extension UnitIlluminance: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .lux: "lux"
+        default:   nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitIlluminance?
+        switch identifier {
+        case "lux": unit = .lux
+        default:    unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitInformationStorage+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitInformationStorage+Identifiers.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitInformationStorage`. Unmapped constants (no
+/// regular CLDR id): `nibbles`, `yottabytes`, `zettabytes`, `exabytes`,
+/// `yottabits`, `zettabits`, `exabits`, `petabits`. Also unmapped: all 16 binary
+/// (IEC) constants — `kibibytes`, `mebibytes`, `gibibytes`, `tebibytes`,
+/// `pebibytes`, `exbibytes`, `zebibytes`, `yobibytes`, `kibibits`, `mebibits`,
+/// `gibibits`, `tebibits`, `pebibits`, `exbibits`, `zebibits`, `yobibits` — because
+/// CLDR's digital-information ids are decimal-only.
+extension UnitInformationStorage: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .bytes:     "byte"
+        case .bits:      "bit"
+        case .petabytes: "petabyte"
+        case .terabytes: "terabyte"
+        case .gigabytes: "gigabyte"
+        case .megabytes: "megabyte"
+        case .kilobytes: "kilobyte"
+        case .terabits:  "terabit"
+        case .gigabits:  "gigabit"
+        case .megabits:  "megabit"
+        case .kilobits:  "kilobit"
+        default:         nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitInformationStorage?
+        switch identifier {
+        case "byte":     unit = .bytes
+        case "bit":      unit = .bits
+        case "petabyte": unit = .petabytes
+        case "terabyte": unit = .terabytes
+        case "gigabyte": unit = .gigabytes
+        case "megabyte": unit = .megabytes
+        case "kilobyte": unit = .kilobytes
+        case "terabit":  unit = .terabits
+        case "gigabit":  unit = .gigabits
+        case "megabit":  unit = .megabits
+        case "kilobit":  unit = .kilobits
+        default:         unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitLength+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitLength+Identifiers.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitLength`. Unmapped constants (no regular CLDR id):
+/// `megameters`, `hectometers`, `decameters`.
+extension UnitLength: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .kilometers:        "kilometer"
+        case .meters:            "meter"
+        case .decimeters:        "decimeter"
+        case .centimeters:       "centimeter"
+        case .millimeters:       "millimeter"
+        case .micrometers:       "micrometer"
+        case .nanometers:        "nanometer"
+        case .picometers:        "picometer"
+        case .inches:            "inch"
+        case .feet:              "foot"
+        case .yards:             "yard"
+        case .miles:             "mile"
+        case .scandinavianMiles: "mile-scandinavian"
+        case .lightyears:        "light-year"
+        case .nauticalMiles:     "nautical-mile"
+        case .fathoms:           "fathom"
+        case .furlongs:          "furlong"
+        case .astronomicalUnits: "astronomical-unit"
+        case .parsecs:           "parsec"
+        default:                 nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitLength?
+        switch identifier {
+        case "kilometer":         unit = .kilometers
+        case "meter":             unit = .meters
+        case "decimeter":         unit = .decimeters
+        case "centimeter":        unit = .centimeters
+        case "millimeter":        unit = .millimeters
+        case "micrometer":        unit = .micrometers
+        case "nanometer":         unit = .nanometers
+        case "picometer":         unit = .picometers
+        case "inch":              unit = .inches
+        case "foot":              unit = .feet
+        case "yard":              unit = .yards
+        case "mile":              unit = .miles
+        case "mile-scandinavian": unit = .scandinavianMiles
+        case "light-year":        unit = .lightyears
+        case "nautical-mile":     unit = .nauticalMiles
+        case "fathom":            unit = .fathoms
+        case "furlong":           unit = .furlongs
+        case "astronomical-unit": unit = .astronomicalUnits
+        case "parsec":            unit = .parsecs
+        default:                  unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitMass+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitMass+Identifiers.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitMass`. Unmapped constants (no regular CLDR id):
+/// `decigrams`, `centigrams`, `nanograms`, `picograms`.
+extension UnitMass: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .kilograms:  "kilogram"
+        case .grams:      "gram"
+        case .milligrams: "milligram"
+        case .micrograms: "microgram"
+        case .ounces:     "ounce"
+        case .pounds:     "pound"
+        case .stones:     "stone"
+        case .metricTons: "tonne"
+        case .shortTons:  "ton"
+        case .carats:     "carat"
+        case .ouncesTroy: "ounce-troy"
+        case .slugs:      "slug"
+        default:          nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitMass?
+        switch identifier {
+        case "kilogram":   unit = .kilograms
+        case "gram":       unit = .grams
+        case "milligram":  unit = .milligrams
+        case "microgram":  unit = .micrograms
+        case "ounce":      unit = .ounces
+        case "pound":      unit = .pounds
+        case "stone":      unit = .stones
+        case "tonne":      unit = .metricTons
+        case "ton":        unit = .shortTons
+        case "carat":      unit = .carats
+        case "ounce-troy": unit = .ouncesTroy
+        case "slug":       unit = .slugs
+        default:           unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitPower+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitPower+Identifiers.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitPower`. Unmapped constants (no regular CLDR id):
+/// `terawatts`, `microwatts`, `nanowatts`, `picowatts`, `femtowatts`.
+extension UnitPower: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .gigawatts:  "gigawatt"
+        case .megawatts:  "megawatt"
+        case .kilowatts:  "kilowatt"
+        case .watts:      "watt"
+        case .milliwatts: "milliwatt"
+        case .horsepower: "horsepower"
+        default:          nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitPower?
+        switch identifier {
+        case "gigawatt":   unit = .gigawatts
+        case "megawatt":   unit = .megawatts
+        case "kilowatt":   unit = .kilowatts
+        case "watt":       unit = .watts
+        case "milliwatt":  unit = .milliwatts
+        case "horsepower": unit = .horsepower
+        default:           unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitPressure+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitPressure+Identifiers.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitPressure`. Unmapped constants (no regular CLDR
+/// id): `gigapascals`.
+extension UnitPressure: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .newtonsPerMetersSquared:  "pascal"
+        case .megapascals:              "megapascal"
+        case .kilopascals:              "kilopascal"
+        case .hectopascals:             "hectopascal"
+        case .inchesOfMercury:          "inch-ofhg"
+        case .bars:                     "bar"
+        case .millibars:                "millibar"
+        case .millimetersOfMercury:     "millimeter-ofhg"
+        case .poundsForcePerSquareInch: "pound-force-per-square-inch"
+        default:                        nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitPressure?
+        switch identifier {
+        case "pascal":                      unit = .newtonsPerMetersSquared
+        case "megapascal":                  unit = .megapascals
+        case "kilopascal":                  unit = .kilopascals
+        case "hectopascal":                 unit = .hectopascals
+        case "inch-ofhg":                   unit = .inchesOfMercury
+        case "bar":                         unit = .bars
+        case "millibar":                    unit = .millibars
+        case "millimeter-ofhg":             unit = .millimetersOfMercury
+        case "pound-force-per-square-inch": unit = .poundsForcePerSquareInch
+        default:                            unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitSpeed+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitSpeed+Identifiers.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitSpeed`. All constants are mapped.
+extension UnitSpeed: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .metersPerSecond:   "meter-per-second"
+        case .kilometersPerHour: "kilometer-per-hour"
+        case .milesPerHour:      "mile-per-hour"
+        case .knots:             "knot"
+        default:                 nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitSpeed?
+        switch identifier {
+        case "meter-per-second":   unit = .metersPerSecond
+        case "kilometer-per-hour": unit = .kilometersPerHour
+        case "mile-per-hour":      unit = .milesPerHour
+        case "knot":               unit = .knots
+        default:                   unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitTemperature+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitTemperature+Identifiers.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitTemperature`. All constants are mapped.
+extension UnitTemperature: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .kelvin:     "kelvin"
+        case .celsius:    "celsius"
+        case .fahrenheit: "fahrenheit"
+        default:          nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitTemperature?
+        switch identifier {
+        case "kelvin":     unit = .kelvin
+        case "celsius":    unit = .celsius
+        case "fahrenheit": unit = .fahrenheit
+        default:           unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Sources/SwiftMeasurementCodable/Units/UnitVolume+Identifiers.swift
+++ b/Sources/SwiftMeasurementCodable/Units/UnitVolume+Identifiers.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// CLDR 48.2 identifiers for `UnitVolume`. Unmapped constants (no regular CLDR id):
+/// `kiloliters`, `cubicDecimeters`, `cubicMillimeters`, `imperialTeaspoons`,
+/// `imperialTablespoons`. `cups` is also deliberately unmapped: Foundation's `cups`
+/// is the 240 mL US legal cup, while CLDR's `cup` is the 236.588 mL customary cup —
+/// the conversion factors disagree, so mapping them would be wrong.
+extension UnitVolume: UnitIdentifierRepresentable {
+    public var unitIdentifier: String? {
+        switch self {
+        case .megaliters:          "megaliter"
+        case .liters:              "liter"
+        case .deciliters:          "deciliter"
+        case .centiliters:         "centiliter"
+        case .milliliters:         "milliliter"
+        case .cubicKilometers:     "cubic-kilometer"
+        case .cubicMeters:         "cubic-meter"
+        case .cubicCentimeters:    "cubic-centimeter"
+        case .cubicInches:         "cubic-inch"
+        case .cubicFeet:           "cubic-foot"
+        case .cubicYards:          "cubic-yard"
+        case .cubicMiles:          "cubic-mile"
+        case .acreFeet:            "acre-foot"
+        case .bushels:             "bushel"
+        case .teaspoons:           "teaspoon"
+        case .tablespoons:         "tablespoon"
+        case .fluidOunces:         "fluid-ounce"
+        case .pints:               "pint"
+        case .quarts:              "quart"
+        case .gallons:             "gallon"
+        case .imperialFluidOunces: "fluid-ounce-imperial"
+        case .imperialPints:       "pint-imperial"
+        case .imperialQuarts:      "quart-imperial"
+        case .imperialGallons:     "gallon-imperial"
+        case .metricCups:          "cup-metric"
+        default:                   nil
+        }
+    }
+
+    public static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitVolume?
+        switch identifier {
+        case "megaliter":            unit = .megaliters
+        case "liter":                unit = .liters
+        case "deciliter":            unit = .deciliters
+        case "centiliter":           unit = .centiliters
+        case "milliliter":           unit = .milliliters
+        case "cubic-kilometer":      unit = .cubicKilometers
+        case "cubic-meter":          unit = .cubicMeters
+        case "cubic-centimeter":     unit = .cubicCentimeters
+        case "cubic-inch":           unit = .cubicInches
+        case "cubic-foot":           unit = .cubicFeet
+        case "cubic-yard":           unit = .cubicYards
+        case "cubic-mile":           unit = .cubicMiles
+        case "acre-foot":            unit = .acreFeet
+        case "bushel":               unit = .bushels
+        case "teaspoon":             unit = .teaspoons
+        case "tablespoon":           unit = .tablespoons
+        case "fluid-ounce":          unit = .fluidOunces
+        case "pint":                 unit = .pints
+        case "quart":                unit = .quarts
+        case "gallon":               unit = .gallons
+        case "fluid-ounce-imperial": unit = .imperialFluidOunces
+        case "pint-imperial":        unit = .imperialPints
+        case "quart-imperial":       unit = .imperialQuarts
+        case "gallon-imperial":      unit = .imperialGallons
+        case "cup-metric":           unit = .metricCups
+        default:                     unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
@@ -4,11 +4,7 @@ import SwiftMeasurementCodable
 
 @Suite("CodableMeasurement")
 struct CodableMeasurementTests {
-    private var sortedKeysEncoder: JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        return encoder
-    }
+    private var sortedKeysEncoder: JSONEncoder { .sortedKeysForTests }
 
     @Test func encodesExactWireBytes() throws {
         let wrapped = Measurement(value: 21.5, unit: UnitMass.grams).codable

--- a/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
@@ -63,7 +63,7 @@ struct CodableMeasurementTests {
     }
 
     @Test func unmappedUnitThrowsEncodingError() {
-        let custom = Measurement(value: 1, unit: UnitMass(symbol: "scoop"))
+        let custom = Measurement(value: 1, unit: UnitMass(symbol: "scoop", converter: UnitConverterLinear(coefficient: 1)))
         #expect(throws: EncodingError.self) {
             _ = try sortedKeysEncoder.encode(CodableMeasurement(custom))
         }

--- a/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/CodableMeasurementTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("CodableMeasurement")
+struct CodableMeasurementTests {
+    private var sortedKeysEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    @Test func encodesExactWireBytes() throws {
+        let wrapped = Measurement(value: 21.5, unit: UnitMass.grams).codable
+        let data = try sortedKeysEncoder.encode(wrapped)
+        #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"gram","value":21.5}"#)
+    }
+
+    @Test func encodesCurrentUnitWithoutCanonicalizing() throws {
+        let wrapped = Measurement(value: 1, unit: UnitMass.ounces).codable
+        let data = try sortedKeysEncoder.encode(wrapped)
+        #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"ounce","value":1}"#)
+    }
+
+    @Test func decodesKnownIdentifier() throws {
+        let json = Data(#"{"value":21.5,"unit":"gram"}"#.utf8)
+        let wrapped = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        #expect(wrapped.measurement == Measurement(value: 21.5, unit: UnitMass.grams))
+    }
+
+    @Test func decodedUnitConverts() throws {
+        let json = Data(#"{"value":1,"unit":"ounce"}"#.utf8)
+        let wrapped = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        let grams = wrapped.measurement.converted(to: .grams).value
+        #expect(abs(grams - 28.3495) < 0.001)
+    }
+
+    @Test func unknownIdentifierThrowsDecodingError() {
+        let json = Data(#"{"value":1,"unit":"parsec"}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        }
+    }
+
+    @Test func missingUnitKeyThrows() {
+        let json = Data(#"{"value":1}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        }
+    }
+
+    @Test func mistypedValueThrows() {
+        let json = Data(#"{"value":"heavy","unit":"gram"}"#.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        }
+    }
+
+    @Test func extraKeysAreIgnored() throws {
+        let json = Data(#"{"value":2,"unit":"gram","note":"extra"}"#.utf8)
+        let wrapped = try JSONDecoder().decode(CodableMeasurement<UnitMass>.self, from: json)
+        #expect(wrapped.measurement.value == 2)
+    }
+
+    @Test func unmappedUnitThrowsEncodingError() {
+        let custom = Measurement(value: 1, unit: UnitMass(symbol: "scoop"))
+        #expect(throws: EncodingError.self) {
+            _ = try sortedKeysEncoder.encode(CodableMeasurement(custom))
+        }
+    }
+
+    @Test func roundTripsInsideParentType() throws {
+        struct Payload: Codable, Equatable {
+            var mass: CodableMeasurement<UnitMass>
+            var tare: CodableMeasurement<UnitMass>
+        }
+        let payload = Payload(
+            mass: Measurement(value: 21.5, unit: UnitMass.grams).codable,
+            tare: Measurement(value: 2, unit: UnitMass.grams).codable
+        )
+        let data = try sortedKeysEncoder.encode(payload)
+        #expect(String(decoding: data, as: UTF8.self)
+            == #"{"mass":{"unit":"gram","value":21.5},"tare":{"unit":"gram","value":2}}"#)
+        let decoded = try JSONDecoder().decode(Payload.self, from: data)
+        #expect(decoded == payload)
+    }
+
+    @Test func equatableComparesAcrossUnits() {
+        let kilo = Measurement(value: 1, unit: UnitMass.kilograms).codable
+        let grams = Measurement(value: 1000, unit: UnitMass.grams).codable
+        #expect(kilo == grams)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/CustomUnitConformanceTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/CustomUnitConformanceTests.swift
@@ -3,7 +3,8 @@ import Testing
 import SwiftMeasurementCodable
 
 /// A consumer-defined Dimension subclass, proving the public extension point.
-private final class UnitCrateCount: Dimension, @unchecked Sendable {
+/// Non-`final` so `UnitDeepCrate` below can exercise the `as? Self` subclass guard.
+private class UnitCrateCount: Dimension, @unchecked Sendable {
     static let crates = UnitCrateCount(symbol: "crate", converter: UnitConverterLinear(coefficient: 1))
     static let pallets = UnitCrateCount(symbol: "pallet", converter: UnitConverterLinear(coefficient: 48))
 
@@ -11,6 +12,11 @@ private final class UnitCrateCount: Dimension, @unchecked Sendable {
         crates as! Self
     }
 }
+
+/// A further subclass of a conforming unit — used only to exercise the `as? Self`
+/// cast in `unit(forIdentifier:)`, which must return `nil` because a base
+/// `UnitCrateCount` instance is not a `UnitDeepCrate`.
+private final class UnitDeepCrate: UnitCrateCount {}
 
 extension UnitCrateCount: UnitIdentifierRepresentable {
     var unitIdentifier: String? {
@@ -42,8 +48,7 @@ struct CustomUnitConformanceTests {
     }
 
     @Test func customUnitEncodesViaWrapper() throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
+        let encoder = JSONEncoder.sortedKeysForTests
         let data = try encoder.encode(Measurement(value: 3, unit: UnitCrateCount.pallets).codable)
         #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"pallet","value":3}"#)
     }
@@ -52,5 +57,12 @@ struct CustomUnitConformanceTests {
         let json = Data(#"{"value":2,"unit":"pallet"}"#.utf8)
         let decoded = try JSONDecoder().decode(CodableMeasurement<UnitCrateCount>.self, from: json)
         #expect(decoded.measurement.converted(to: .crates).value == 96)
+    }
+
+    @Test func subclassLookupFailsTheAsSelfCastToNil() {
+        // The standard constants are `UnitCrateCount` instances, so resolving one
+        // through a subclass type must fail `unit as? Self` and yield nil — the
+        // guarantee the `as? Self` idiom in all 22 conformance files provides.
+        #expect(UnitDeepCrate.unit(forIdentifier: "crate") == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/CustomUnitConformanceTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/CustomUnitConformanceTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+/// A consumer-defined Dimension subclass, proving the public extension point.
+private final class UnitCrateCount: Dimension, @unchecked Sendable {
+    static let crates = UnitCrateCount(symbol: "crate", converter: UnitConverterLinear(coefficient: 1))
+    static let pallets = UnitCrateCount(symbol: "pallet", converter: UnitConverterLinear(coefficient: 48))
+
+    override class func baseUnit() -> Self {
+        crates as! Self
+    }
+}
+
+extension UnitCrateCount: UnitIdentifierRepresentable {
+    var unitIdentifier: String? {
+        switch self {
+        case .crates:  "crate"
+        case .pallets: "pallet"
+        default:       nil
+        }
+    }
+
+    static func unit(forIdentifier identifier: String) -> Self? {
+        let unit: UnitCrateCount?
+        switch identifier {
+        case "crate":  unit = .crates
+        case "pallet": unit = .pallets
+        default:       unit = nil
+        }
+        guard let unit else { return nil }
+        return unit as? Self
+    }
+}
+
+@Suite("Custom unit conformance")
+struct CustomUnitConformanceTests {
+    @Test func customUnitRoundTripsIdentifiers() {
+        #expect(UnitCrateCount.crates.unitIdentifier == "crate")
+        #expect(UnitCrateCount.unit(forIdentifier: "pallet") == .pallets)
+        #expect(UnitCrateCount.unit(forIdentifier: "container") == nil)
+    }
+
+    @Test func customUnitEncodesViaWrapper() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(Measurement(value: 3, unit: UnitCrateCount.pallets).codable)
+        #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"pallet","value":3}"#)
+    }
+
+    @Test func customUnitDecodesAndConverts() throws {
+        let json = Data(#"{"value":2,"unit":"pallet"}"#.utf8)
+        let decoded = try JSONDecoder().decode(CodableMeasurement<UnitCrateCount>.self, from: json)
+        #expect(decoded.measurement.converted(to: .crates).value == 96)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/RawMeasurementTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/RawMeasurementTests.swift
@@ -21,8 +21,7 @@ struct RawMeasurementTests {
     }
 
     @Test func encodesUnderUnitKey() throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
+        let encoder = JSONEncoder.sortedKeysForTests
         let data = try encoder.encode(RawMeasurement(value: 9.5, unitIdentifier: "smidgen"))
         #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"smidgen","value":9.5}"#)
     }

--- a/Tests/SwiftMeasurementCodableTests/RawMeasurementTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/RawMeasurementTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("RawMeasurement")
+struct RawMeasurementTests {
+    @Test func decodesUnknownIdentifier() throws {
+        let json = Data(#"{"value":9.5,"unit":"smidgen"}"#.utf8)
+        let raw = try JSONDecoder().decode(RawMeasurement.self, from: json)
+        #expect(raw == RawMeasurement(value: 9.5, unitIdentifier: "smidgen"))
+    }
+
+    @Test func typedAccessorReturnsNilForUnknown() {
+        let raw = RawMeasurement(value: 9.5, unitIdentifier: "smidgen")
+        #expect(raw.measurement(as: UnitMass.self) == nil)
+    }
+
+    @Test func typedAccessorBuildsMeasurement() {
+        let raw = RawMeasurement(value: 21.5, unitIdentifier: "gram")
+        #expect(raw.measurement(as: UnitMass.self) == Measurement(value: 21.5, unit: UnitMass.grams))
+    }
+
+    @Test func encodesUnderUnitKey() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(RawMeasurement(value: 9.5, unitIdentifier: "smidgen"))
+        #expect(String(decoding: data, as: UTF8.self) == #"{"unit":"smidgen","value":9.5}"#)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/TestSupport.swift
+++ b/Tests/SwiftMeasurementCodableTests/TestSupport.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension JSONEncoder {
+    /// A `JSONEncoder` with `.sortedKeys` for deterministic wire-byte assertions in tests.
+    static var sortedKeysForTests: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAccelerationIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAccelerationIdentifierTests.swift
@@ -26,6 +26,6 @@ struct UnitAccelerationIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitAcceleration.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitAcceleration(symbol: "??").unitIdentifier == nil)
+        #expect(UnitAcceleration(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAccelerationIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAccelerationIdentifierTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitAcceleration identifiers")
+struct UnitAccelerationIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitAcceleration)] {
+        [
+            ("meter-per-square-second", .metersPerSecondSquared),
+            ("g-force", .gravity),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitAcceleration.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitAcceleration.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitAcceleration(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAngleIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAngleIdentifierTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitAngle identifiers")
+struct UnitAngleIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitAngle)] {
+        [
+            ("degree", .degrees),
+            ("arc-minute", .arcMinutes),
+            ("arc-second", .arcSeconds),
+            ("radian", .radians),
+            ("revolution", .revolutions),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitAngle.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitAngle.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitAngle(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAngleIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAngleIdentifierTests.swift
@@ -29,6 +29,6 @@ struct UnitAngleIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitAngle.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitAngle(symbol: "??").unitIdentifier == nil)
+        #expect(UnitAngle(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAreaIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAreaIdentifierTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitArea identifiers")
+struct UnitAreaIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitArea)] {
+        [
+            ("square-kilometer", .squareKilometers),
+            ("square-meter", .squareMeters),
+            ("square-centimeter", .squareCentimeters),
+            ("square-inch", .squareInches),
+            ("square-foot", .squareFeet),
+            ("square-yard", .squareYards),
+            ("square-mile", .squareMiles),
+            ("acre", .acres),
+            ("hectare", .hectares),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitArea.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitArea.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitArea(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitAreaIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitAreaIdentifierTests.swift
@@ -33,6 +33,6 @@ struct UnitAreaIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitArea.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitArea(symbol: "??").unitIdentifier == nil)
+        #expect(UnitArea(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitConcentrationMassIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitConcentrationMassIdentifierTests.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitConcentrationMass identifiers")
+struct UnitConcentrationMassIdentifierTests {
+    @Test func noIdentifiersAreMapped() {
+        #expect(UnitConcentrationMass.unit(forIdentifier: "gram-per-liter") == nil)
+        #expect(UnitConcentrationMass.gramsPerLiter.unitIdentifier == nil)
+        #expect(UnitConcentrationMass.milligramsPerDeciliter.unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitDispersionIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitDispersionIdentifierTests.swift
@@ -25,6 +25,6 @@ struct UnitDispersionIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitDispersion.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitDispersion(symbol: "??").unitIdentifier == nil)
+        #expect(UnitDispersion(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitDispersionIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitDispersionIdentifierTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitDispersion identifiers")
+struct UnitDispersionIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitDispersion)] {
+        [
+            ("part-per-1e6", .partsPerMillion),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitDispersion.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitDispersion.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitDispersion(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitDurationIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitDurationIdentifierTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitDuration identifiers")
+struct UnitDurationIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitDuration)] {
+        [
+            ("hour", .hours),
+            ("minute", .minutes),
+            ("second", .seconds),
+            ("millisecond", .milliseconds),
+            ("microsecond", .microseconds),
+            ("nanosecond", .nanoseconds),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitDuration.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitDuration.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitDuration(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitDurationIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitDurationIdentifierTests.swift
@@ -30,6 +30,6 @@ struct UnitDurationIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitDuration.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitDuration(symbol: "??").unitIdentifier == nil)
+        #expect(UnitDuration(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricChargeIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricChargeIdentifierTests.swift
@@ -25,6 +25,6 @@ struct UnitElectricChargeIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitElectricCharge.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitElectricCharge(symbol: "??").unitIdentifier == nil)
+        #expect(UnitElectricCharge(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricChargeIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricChargeIdentifierTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitElectricCharge identifiers")
+struct UnitElectricChargeIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitElectricCharge)] {
+        [
+            ("coulomb", .coulombs),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitElectricCharge.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitElectricCharge.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitElectricCharge(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricCurrentIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricCurrentIdentifierTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitElectricCurrent identifiers")
+struct UnitElectricCurrentIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitElectricCurrent)] {
+        [
+            ("ampere", .amperes),
+            ("milliampere", .milliamperes),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitElectricCurrent.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitElectricCurrent.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitElectricCurrent(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricCurrentIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricCurrentIdentifierTests.swift
@@ -26,6 +26,6 @@ struct UnitElectricCurrentIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitElectricCurrent.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitElectricCurrent(symbol: "??").unitIdentifier == nil)
+        #expect(UnitElectricCurrent(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricPotentialDifferenceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricPotentialDifferenceIdentifierTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitElectricPotentialDifference identifiers")
+struct UnitElectricPotentialDifferenceIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitElectricPotentialDifference)] {
+        [
+            ("volt", .volts),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitElectricPotentialDifference.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitElectricPotentialDifference.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitElectricPotentialDifference(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricPotentialDifferenceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricPotentialDifferenceIdentifierTests.swift
@@ -25,6 +25,6 @@ struct UnitElectricPotentialDifferenceIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitElectricPotentialDifference.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitElectricPotentialDifference(symbol: "??").unitIdentifier == nil)
+        #expect(UnitElectricPotentialDifference(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricResistanceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricResistanceIdentifierTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitElectricResistance identifiers")
+struct UnitElectricResistanceIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitElectricResistance)] {
+        [
+            ("ohm", .ohms),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitElectricResistance.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitElectricResistance.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitElectricResistance(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitElectricResistanceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitElectricResistanceIdentifierTests.swift
@@ -25,6 +25,6 @@ struct UnitElectricResistanceIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitElectricResistance.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitElectricResistance(symbol: "??").unitIdentifier == nil)
+        #expect(UnitElectricResistance(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitEnergyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitEnergyIdentifierTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitEnergy identifiers")
+struct UnitEnergyIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitEnergy)] {
+        [
+            ("kilojoule", .kilojoules),
+            ("joule", .joules),
+            ("kilocalorie", .kilocalories),
+            ("calorie", .calories),
+            ("kilowatt-hour", .kilowattHours),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitEnergy.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitEnergy.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitEnergy(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitEnergyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitEnergyIdentifierTests.swift
@@ -29,6 +29,6 @@ struct UnitEnergyIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitEnergy.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitEnergy(symbol: "??").unitIdentifier == nil)
+        #expect(UnitEnergy(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitFrequencyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitFrequencyIdentifierTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitFrequency identifiers")
+struct UnitFrequencyIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitFrequency)] {
+        [
+            ("gigahertz", .gigahertz),
+            ("megahertz", .megahertz),
+            ("kilohertz", .kilohertz),
+            ("hertz", .hertz),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitFrequency.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitFrequency.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitFrequency(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitFrequencyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitFrequencyIdentifierTests.swift
@@ -28,6 +28,6 @@ struct UnitFrequencyIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitFrequency.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitFrequency(symbol: "??").unitIdentifier == nil)
+        #expect(UnitFrequency(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitFuelEfficiencyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitFuelEfficiencyIdentifierTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitFuelEfficiency identifiers")
+struct UnitFuelEfficiencyIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitFuelEfficiency)] {
+        [
+            ("liter-per-100-kilometer", .litersPer100Kilometers),
+            ("mile-per-gallon", .milesPerGallon),
+            ("mile-per-gallon-imperial", .milesPerImperialGallon),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitFuelEfficiency.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitFuelEfficiency.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitFuelEfficiency(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitFuelEfficiencyIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitFuelEfficiencyIdentifierTests.swift
@@ -27,6 +27,6 @@ struct UnitFuelEfficiencyIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitFuelEfficiency.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitFuelEfficiency(symbol: "??").unitIdentifier == nil)
+        #expect(UnitFuelEfficiency(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitIlluminanceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitIlluminanceIdentifierTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitIlluminance identifiers")
+struct UnitIlluminanceIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitIlluminance)] {
+        [
+            ("lux", .lux),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitIlluminance.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitIlluminance.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitIlluminance(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitIlluminanceIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitIlluminanceIdentifierTests.swift
@@ -25,6 +25,6 @@ struct UnitIlluminanceIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitIlluminance.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitIlluminance(symbol: "??").unitIdentifier == nil)
+        #expect(UnitIlluminance(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitInformationStorageIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitInformationStorageIdentifierTests.swift
@@ -35,6 +35,6 @@ struct UnitInformationStorageIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitInformationStorage.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitInformationStorage(symbol: "??").unitIdentifier == nil)
+        #expect(UnitInformationStorage(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitInformationStorageIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitInformationStorageIdentifierTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitInformationStorage identifiers")
+struct UnitInformationStorageIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitInformationStorage)] {
+        [
+            ("byte", .bytes),
+            ("bit", .bits),
+            ("petabyte", .petabytes),
+            ("terabyte", .terabytes),
+            ("gigabyte", .gigabytes),
+            ("megabyte", .megabytes),
+            ("kilobyte", .kilobytes),
+            ("terabit", .terabits),
+            ("gigabit", .gigabits),
+            ("megabit", .megabits),
+            ("kilobit", .kilobits),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitInformationStorage.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitInformationStorage.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitInformationStorage(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitLengthIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitLengthIdentifierTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitLength identifiers")
+struct UnitLengthIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitLength)] {
+        [
+            ("kilometer", .kilometers),
+            ("meter", .meters),
+            ("decimeter", .decimeters),
+            ("centimeter", .centimeters),
+            ("millimeter", .millimeters),
+            ("micrometer", .micrometers),
+            ("nanometer", .nanometers),
+            ("picometer", .picometers),
+            ("inch", .inches),
+            ("foot", .feet),
+            ("yard", .yards),
+            ("mile", .miles),
+            ("mile-scandinavian", .scandinavianMiles),
+            ("light-year", .lightyears),
+            ("nautical-mile", .nauticalMiles),
+            ("fathom", .fathoms),
+            ("furlong", .furlongs),
+            ("astronomical-unit", .astronomicalUnits),
+            ("parsec", .parsecs),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitLength.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitLength.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitLength(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitLengthIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitLengthIdentifierTests.swift
@@ -43,6 +43,6 @@ struct UnitLengthIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitLength.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitLength(symbol: "??").unitIdentifier == nil)
+        #expect(UnitLength(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitMassIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitMassIdentifierTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitMass identifiers")
+struct UnitMassIdentifierTests {
+    /// Independent statement of the expected mapping — deliberately duplicates the
+    /// implementation's table so a transcription slip in either place fails the suite.
+    /// Computed (not stored) so the non-Sendable `Unit` values are never static state.
+    static var expected: [(identifier: String, unit: UnitMass)] {
+        [
+            ("kilogram", .kilograms),
+            ("gram", .grams),
+            ("milligram", .milligrams),
+            ("microgram", .micrograms),
+            ("ounce", .ounces),
+            ("pound", .pounds),
+            ("stone", .stones),
+            ("tonne", .metricTons),
+            ("ton", .shortTons),
+            ("carat", .carats),
+            ("ounce-troy", .ouncesTroy),
+            ("slug", .slugs),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitMass.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitMass.unit(forIdentifier: "parsec") == nil)
+        #expect(UnitMass.unit(forIdentifier: "") == nil)
+        #expect(UnitMass(symbol: "zz").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitMassIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitMassIdentifierTests.swift
@@ -40,6 +40,6 @@ struct UnitMassIdentifierTests {
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitMass.unit(forIdentifier: "parsec") == nil)
         #expect(UnitMass.unit(forIdentifier: "") == nil)
-        #expect(UnitMass(symbol: "zz").unitIdentifier == nil)
+        #expect(UnitMass(symbol: "zz", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitPowerIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitPowerIdentifierTests.swift
@@ -30,6 +30,6 @@ struct UnitPowerIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitPower.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitPower(symbol: "??").unitIdentifier == nil)
+        #expect(UnitPower(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitPowerIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitPowerIdentifierTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitPower identifiers")
+struct UnitPowerIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitPower)] {
+        [
+            ("gigawatt", .gigawatts),
+            ("megawatt", .megawatts),
+            ("kilowatt", .kilowatts),
+            ("watt", .watts),
+            ("milliwatt", .milliwatts),
+            ("horsepower", .horsepower),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitPower.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitPower.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitPower(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitPressureIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitPressureIdentifierTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitPressure identifiers")
+struct UnitPressureIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitPressure)] {
+        [
+            ("pascal", .newtonsPerMetersSquared),
+            ("megapascal", .megapascals),
+            ("kilopascal", .kilopascals),
+            ("hectopascal", .hectopascals),
+            ("inch-ofhg", .inchesOfMercury),
+            ("bar", .bars),
+            ("millibar", .millibars),
+            ("millimeter-ofhg", .millimetersOfMercury),
+            ("pound-force-per-square-inch", .poundsForcePerSquareInch),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitPressure.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitPressure.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitPressure(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitPressureIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitPressureIdentifierTests.swift
@@ -33,6 +33,6 @@ struct UnitPressureIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitPressure.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitPressure(symbol: "??").unitIdentifier == nil)
+        #expect(UnitPressure(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitSpeedIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitSpeedIdentifierTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitSpeed identifiers")
+struct UnitSpeedIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitSpeed)] {
+        [
+            ("meter-per-second", .metersPerSecond),
+            ("kilometer-per-hour", .kilometersPerHour),
+            ("mile-per-hour", .milesPerHour),
+            ("knot", .knots),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitSpeed.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitSpeed.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitSpeed(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitSpeedIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitSpeedIdentifierTests.swift
@@ -28,6 +28,6 @@ struct UnitSpeedIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitSpeed.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitSpeed(symbol: "??").unitIdentifier == nil)
+        #expect(UnitSpeed(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitTemperatureIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitTemperatureIdentifierTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitTemperature identifiers")
+struct UnitTemperatureIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitTemperature)] {
+        [
+            ("kelvin", .kelvin),
+            ("celsius", .celsius),
+            ("fahrenheit", .fahrenheit),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitTemperature.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitTemperature.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitTemperature(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitTemperatureIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitTemperatureIdentifierTests.swift
@@ -27,6 +27,6 @@ struct UnitTemperatureIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitTemperature.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitTemperature(symbol: "??").unitIdentifier == nil)
+        #expect(UnitTemperature(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitVolumeIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitVolumeIdentifierTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+import SwiftMeasurementCodable
+
+@Suite("UnitVolume identifiers")
+struct UnitVolumeIdentifierTests {
+    static var expected: [(identifier: String, unit: UnitVolume)] {
+        [
+            ("megaliter", .megaliters),
+            ("liter", .liters),
+            ("deciliter", .deciliters),
+            ("centiliter", .centiliters),
+            ("milliliter", .milliliters),
+            ("cubic-kilometer", .cubicKilometers),
+            ("cubic-meter", .cubicMeters),
+            ("cubic-centimeter", .cubicCentimeters),
+            ("cubic-inch", .cubicInches),
+            ("cubic-foot", .cubicFeet),
+            ("cubic-yard", .cubicYards),
+            ("cubic-mile", .cubicMiles),
+            ("acre-foot", .acreFeet),
+            ("bushel", .bushels),
+            ("teaspoon", .teaspoons),
+            ("tablespoon", .tablespoons),
+            ("fluid-ounce", .fluidOunces),
+            ("pint", .pints),
+            ("quart", .quarts),
+            ("gallon", .gallons),
+            ("fluid-ounce-imperial", .imperialFluidOunces),
+            ("pint-imperial", .imperialPints),
+            ("quart-imperial", .imperialQuarts),
+            ("gallon-imperial", .imperialGallons),
+            ("cup-metric", .metricCups),
+        ]
+    }
+
+    @Test func identifiersRoundTrip() {
+        for (identifier, unit) in Self.expected {
+            #expect(unit.unitIdentifier == identifier)
+            #expect(UnitVolume.unit(forIdentifier: identifier) == unit)
+        }
+    }
+
+    @Test func identifiersMatchGrammar() {
+        for (identifier, _) in Self.expected {
+            #expect(identifier.wholeMatch(of: /[a-z0-9-]+/) != nil)
+        }
+    }
+
+    @Test func unknownIdentifierReturnsNil() {
+        #expect(UnitVolume.unit(forIdentifier: "no-such-unit") == nil)
+        #expect(UnitVolume(symbol: "??").unitIdentifier == nil)
+    }
+}

--- a/Tests/SwiftMeasurementCodableTests/Units/UnitVolumeIdentifierTests.swift
+++ b/Tests/SwiftMeasurementCodableTests/Units/UnitVolumeIdentifierTests.swift
@@ -49,6 +49,6 @@ struct UnitVolumeIdentifierTests {
 
     @Test func unknownIdentifierReturnsNil() {
         #expect(UnitVolume.unit(forIdentifier: "no-such-unit") == nil)
-        #expect(UnitVolume(symbol: "??").unitIdentifier == nil)
+        #expect(UnitVolume(symbol: "??", converter: UnitConverterLinear(coefficient: 1)).unitIdentifier == nil)
     }
 }


### PR DESCRIPTION
## Summary

Adds a new standalone `SwiftMeasurementCodable` product that encodes and decodes Foundation `Measurement` values as stable, portable JSON — `{"value": 21.5, "unit": "gram"}` — where `unit` is a CLDR 48.2 core unit identifier (the same vocabulary JavaScript's `Intl.NumberFormat` accepts). Foundation's built-in `Measurement` Codable shape leaks display symbols and converter internals, so it is unusable as a wire format; because `Measurement` is already `Codable` and cannot be re-conformed, this uses small wrapper types.

The module imports only Foundation and has no dependency on the `SwiftMeasurement` target.

## What's included

- **`UnitIdentifierRepresentable`** — a public protocol on `Dimension` that maps units to and from CLDR identifiers via two switch statements (no stored tables, no shared state). All 22 Foundation `Dimension` types conform, and consumers can conform their own `Dimension` subclasses.
- **`CodableMeasurement<UnitType>`** — a strict `Codable`/`Equatable`/`Sendable` wrapper that owns the `{"value","unit"}` wire shape and throws `DecodingError` on an unrecognized identifier, plus a `Measurement.codable` convenience.
- **`RawMeasurement`** — a lenient passthrough that never fails on an unknown identifier, with failable typed access via `measurement(as:)`.
- 130 CLDR-mapped constants across all 22 dimension types (regular identifiers only).
- A README section, and a CI job that builds and tests the module on macOS and Linux and verifies it stays standalone.

## Testing

- 270 tests, 0 failures on macOS (Swift 6.3); `swift build -c release` clean.
- The added CI job builds (Debug + Release) and runs the suite on both macOS and Linux (Swift 6.0) on every push/PR, and checks the module does not import the `SwiftMeasurement` target.

## Notes

- Encoding emits the measurement's current unit as-is — convert first (`measurement.converted(to:)`) to control the wire unit.
- A few identifiers (e.g. `bar`) are valid CLDR but fall outside the smaller ECMA-402 subset that `Intl.NumberFormat` formats.
- `CodableMeasurement`'s `Equatable` compares dimensionally (like `Measurement`), so 1 kg equals 1000 g even though they encode to different JSON.
